### PR TITLE
Add favicon and apple touch icon links to login page

### DIFF
--- a/public/login/login.html
+++ b/public/login/login.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="../img/favicon.webp" />
+    <link rel="apple-touch-icon" href="../img/apple-touch-icon.webp" />
     <script
       src="https://kit.fontawesome.com/64d58efce2.js"
       crossorigin="anonymous"


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Add favicon and apple touch icon links to login page

Closes #182 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->
This pull request includes a small change to the `public/login/login.html` file. The change adds links to a favicon and an Apple touch icon to the login page.

* [`public/login/login.html`](diffhunk://#diff-5682aca81aa4ab8e76caa0353c43ea02ebfe9a0310b5b7f6ab0591affd85d948R6-R7): Added links to a favicon (`favicon.webp`) and an Apple touch icon (`apple-touch-icon.webp`).



