### PR TITLE
Fix Missing Rate Limiting on Click Tracking Endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.13.1",
         "node-cron": "^3.0.3",
@@ -382,6 +383,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/finalhandler": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.13.1",
     "node-cron": "^3.0.3",


### PR DESCRIPTION
# PULL REQUEST 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Fix Missing Rate Limiting on Click Tracking Endpoint

Closes #251 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

# 📌 Description
<!-- Description of the issue you are solving -->
This pull request introduces a rate limiting feature to the server to prevent abuse and improve security. It also makes a small adjustment to the bulk write threshold for click tracking.

Rate limiting feature:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R28): Added the `express-rate-limit` package to the dependencies.
* [`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fR7-R23): Imported the `express-rate-limit` package and created a rate limiter that allows 100 requests per IP per hour. Applied this rate limiter to the `/track-click` endpoint. 

Click tracking adjustment:

* [`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL69-R79): Reduced the bulk write threshold for click tracking from 100 to 50 operations.
